### PR TITLE
fix: fix pipelines path in generate-manifests.sh

### DIFF
--- a/.github/workflows/search-new-releases.yaml
+++ b/.github/workflows/search-new-releases.yaml
@@ -15,9 +15,12 @@ jobs:
       with:
         go-version-file: 'go.mod'
     - name: Publish tekton images and generate release manifests
+      env:
+        GH_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+        ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+        REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+      shell: bash
       run: |
-        # Authenticate with gh cli
-        echo "${{ secrets.ACTIONS_TOKEN }}" > token.txt
-        gh auth login --with-token < token.txt
-        rm token.txt
+        skopeo login -u="$REGISTRY_USERNAME" -p="$REGISTRY_PASSWORD" registry.redhat.io
         ./check-for-new-release.sh

--- a/check-for-new-release.sh
+++ b/check-for-new-release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
  
-existing_tags=$(skopeo list-tags docker://registry.access.redhat.com/container-native-virtualization/kubevirt-tekton-tasks-create-datavolume-rhel9 | jq '.Tags | sort | join(",")')
+existing_tags=$(skopeo list-tags docker://registry.redhat.io/container-native-virtualization/kubevirt-tekton-tasks-create-datavolume-rhel9 | jq '.Tags | sort | join(",")')
 
 go run main.go --existing-tags="${existing_tags}" --minimal-version="v4.15" --dry-run=false --repository-url="https://github.com/openshift-cnv/openshift-virtualization-pipelines-tasks"

--- a/generate-manifests.sh
+++ b/generate-manifests.sh
@@ -19,6 +19,6 @@ do
 	rm -r "tasks/${TASK_NAME}"
 done
 #delete pipelines, which are not published
-rm -r "pipelines/windows-bios-installer" "pipelines/windows/customize"
+rm -r "release/pipelines/windows-bios-installer" "release/pipelines/windows/customize"
 
 ../run-catalog-cd.sh


### PR DESCRIPTION
fix: fix pipelines path in generate-manifests.sh

It pointed to old path, which is no longer used