### PR TITLE
fix: use RH OCP cli image instead of upstream one

### DIFF
--- a/ansible/variables.yaml
+++ b/ansible/variables.yaml
@@ -3,6 +3,6 @@ catalog: redhat-tekton-tasks
 catalog_type: artifact
 pipelines_catalog: redhat-pipelines
 
-openshift_client_catalog: tekton-catalog-tasks
-openshift_client_task_version: 0.2.0
+openshift_client_catalog: redhat-tekton-tasks
+openshift_client_task_version: 0.2.2
 openshift_client_oc_version: latest


### PR DESCRIPTION
The RH image is available in multiple architectures which is needed for future work